### PR TITLE
Cleanup after renew

### DIFF
--- a/src/testing.rs
+++ b/src/testing.rs
@@ -369,6 +369,16 @@ impl InMemoryRuntime {
         let taken = self.to_schedule.swap_remove(position);
         Some(taken.1)
     }
+
+    pub fn find_scheduling<F>(&self, predicate: F) -> Option<&Timer<ID>>
+    where
+        F: Fn(&Timer<ID>) -> bool,
+    {
+        self.to_schedule
+            .iter()
+            .find(|(timer, _)| predicate(timer))
+            .map(|(timer, _)| timer)
+    }
 }
 
 impl Runtime<ID> for InMemoryRuntime {


### PR DESCRIPTION
My hunch was right, but took me a while to reproduce the exact error pointed at the issue.

The test `renew_during_probe_shouldnt_cause_errors` can be trivially modified to trigger it now simply [by removing the comment guard from this line](https://github.com/caio/foca/commit/1055529abb04520e69deda3662ec2c6d7b3f88b3#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R2124).

Will merge when CI passes

Resolves #2 