### PR TITLE
Broadcasting extensions

### DIFF
--- a/examples/broadcasting.rs
+++ b/examples/broadcasting.rs
@@ -134,7 +134,7 @@ impl Handler {
     }
 }
 
-impl BroadcastHandler for Handler {
+impl<T> BroadcastHandler<T> for Handler {
     type Broadcast = Broadcast;
     type Error = String;
 

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -130,6 +130,10 @@ pub enum Message<T> {
     /// Deliberate dissemination of cluster updates.
     /// Non-interactive, doesn't expect a reply.
     Gossip,
+
+    /// Deliberate dissemination of custom broadcasts. Broadcast
+    /// messages do not contain cluster updates.
+    Broadcast,
 }
 
 /// ProbeNumber is simply a bookkeeping mechanism to try and prevent

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -184,6 +184,7 @@ impl BadCodec {
             7 => Message::Gossip,
             8 => Message::Announce,
             9 => Message::Feed,
+            10 => Message::Broadcast,
             other => return Err(BadCodecError::BadMessageID(other)),
         };
 
@@ -247,6 +248,9 @@ impl BadCodec {
             }
             Message::Feed => {
                 buf.put_u8(9);
+            }
+            Message::Broadcast => {
+                buf.put_u8(10);
             }
         }
 


### PR DESCRIPTION
This will

- [X] Allow implementations to instruct Foca when to include custom broadcasts on their messages based on their identity
- [x] Expose functionality to guarantee broadcast dissemination

Related: #3 