### PR TITLE
Allow changing configuration at runtime via Foca::set_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,9 @@ EnvFilter directives][dir].
 
 Every feature is optional. The `default` set will always be empty.
 
-* `std`: Adds `std::error::Error` support and implements `foca::Identity`
-  for `std::net::SocketAddr*`.
+* `std`: Adds `std::error::Error` support, implements `foca::Identity`
+  for `std::net::SocketAddr*` and exposes `Config::new_lan` and
+  `Config::new_wan`
 * `tracing`: Instruments Foca using the [tracing][] crate.
 * `serde`: Derives `Serialize` and `Deserialize` for Foca's public
   types.

--- a/src/error.rs
+++ b/src/error.rs
@@ -70,6 +70,13 @@ pub enum Error {
     ///
     /// Doesn't affect Foca's state.
     CustomBroadcast(anyhow::Error),
+
+    /// Configuration change not allowed.
+    ///
+    /// Doesn't affact Foca's state.
+    ///
+    /// See [`crate::Foca::set_config`].
+    InvalidConfig,
 }
 
 impl PartialEq for Error {
@@ -92,6 +99,7 @@ impl PartialEq for Error {
             (Error::DataFromOurselves, Error::DataFromOurselves) => true,
             (Error::IndirectForOurselves, Error::IndirectForOurselves) => true,
             (Error::MalformedPacket, Error::MalformedPacket) => true,
+            (Error::InvalidConfig, Error::InvalidConfig) => true,
 
             // Instead of a catch-all here, we explicitly enumerate our variants
             // so that when/if new errors are added we don't silently introduce
@@ -107,6 +115,7 @@ impl PartialEq for Error {
             (Error::DataFromOurselves, _) => false,
             (Error::IndirectForOurselves, _) => false,
             (Error::MalformedPacket, _) => false,
+            (Error::InvalidConfig, _) => false,
         }
     }
 }
@@ -137,6 +146,7 @@ impl fmt::Display for Error {
             Error::Encode(err) => err.fmt(formatter),
             Error::Decode(err) => err.fmt(formatter),
             Error::CustomBroadcast(err) => err.fmt(formatter),
+            Error::InvalidConfig => formatter.write_str("Invalid configuration"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -618,6 +618,29 @@ where
         self.custom_broadcasts.len()
     }
 
+    /// Replaces the current configuration with a new one.
+    ///
+    /// Most of the time a static configuration is more than enough, but
+    /// for use-cases where the cluster size can drastically change during
+    /// normal operations, changing the configuration parameters is a
+    /// nicer alternative to recreating the Foca instance.
+    ///
+    /// Presently, attempting to change [`Config::probe_period`] or
+    /// [`Config::probe_rtt`] results in [`Error::InvalidConfig`]; For
+    /// such cases it's recommended to recreate your Foca instance. When
+    /// an error occurrs, every configuration parameter remains
+    /// unchanged.
+    pub fn set_config(&mut self, config: Config) -> Result<()> {
+        if self.config.probe_period != config.probe_period
+            || self.config.probe_rtt != config.probe_rtt
+        {
+            Err(Error::InvalidConfig)
+        } else {
+            self.config = config;
+            Ok(())
+        }
+    }
+
     /// Handle data received from the network.
     ///
     /// Data larger than the configured limit will be rejected. Errors are
@@ -1432,6 +1455,31 @@ mod tests {
         );
         assert_eq!(Ok(()), foca.change_identity(ID::new(43), &mut runtime));
         assert_eq!(&ID::new(43), foca.identity());
+    }
+
+    #[test]
+    fn cant_change_config_probe_timers() {
+        let mut foca = Foca::new(ID::new(1), config(), rng(), codec());
+
+        let mut bad_config = config();
+        bad_config.probe_rtt += Duration::from_millis(1);
+
+        assert_eq!(
+            Err(Error::InvalidConfig),
+            foca.set_config(bad_config),
+            "must not be able to change probe_rtt"
+        );
+
+        let mut bad_config = config();
+        bad_config.probe_period -= Duration::from_secs(1);
+
+        assert_eq!(
+            Err(Error::InvalidConfig),
+            foca.set_config(bad_config),
+            "must not be able to change probe_period"
+        );
+
+        assert_eq!(Ok(()), foca.set_config(config()));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,6 @@ where
         broadcast_handler: B,
     ) -> Self {
         let max_indirect_probes = config.num_indirect_probes.get();
-        let max_tx = config.max_transmissions.get().into();
         let max_bytes = config.max_packet_size.get();
         Self {
             identity,
@@ -196,9 +195,9 @@ where
             probe: Probe::new(Vec::with_capacity(max_indirect_probes)),
             member_buf: Vec::new(),
             connection_state: ConnectionState::Disconnected,
-            updates: Broadcasts::new(max_tx),
+            updates: Broadcasts::new(),
             send_buf: BytesMut::with_capacity(max_bytes),
-            custom_broadcasts: Broadcasts::new(max_tx),
+            custom_broadcasts: Broadcasts::new(),
             updates_buf: BytesMut::new(),
             broadcast_handler,
         }
@@ -260,10 +259,13 @@ where
             // we'll declare it ourselves
             if !previous_is_down {
                 let data = self.serialize_member(Member::down(previous_id.clone()))?;
-                self.updates.add_or_replace(ClusterUpdate {
-                    member_id: previous_id,
-                    data,
-                });
+                self.updates.add_or_replace(
+                    ClusterUpdate {
+                        member_id: previous_id,
+                        data,
+                    },
+                    self.config.max_transmissions.get().into(),
+                );
             }
 
             self.gossip(runtime)?;
@@ -415,10 +417,13 @@ where
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(runtime)))]
     pub fn leave_cluster(mut self, mut runtime: impl Runtime<T>) -> Result<()> {
         let data = self.serialize_member(Member::down(self.identity().clone()))?;
-        self.updates.add_or_replace(ClusterUpdate {
-            member_id: self.identity().clone(),
-            data,
-        });
+        self.updates.add_or_replace(
+            ClusterUpdate {
+                member_id: self.identity().clone(),
+                data,
+            },
+            self.config.max_transmissions.get().into(),
+        );
 
         self.gossip(&mut runtime)?;
 
@@ -457,7 +462,8 @@ where
         {
             #[cfg(feature = "tracing")]
             tracing::debug!("new item received");
-            self.custom_broadcasts.add_or_replace(broadcast);
+            self.custom_broadcasts
+                .add_or_replace(broadcast, self.config.max_transmissions.get().into());
         }
 
         Ok(())
@@ -941,10 +947,13 @@ where
         if summary.apply_successful {
             // Cluster state changed, start broadcasting it
             let data = self.serialize_member(update)?;
-            self.updates.add_or_replace(ClusterUpdate {
-                member_id: id.clone(),
-                data,
-            });
+            self.updates.add_or_replace(
+                ClusterUpdate {
+                    member_id: id.clone(),
+                    data,
+                },
+                self.config.max_transmissions.get().into(),
+            );
 
             // Down is a terminal state, so set up a handler for removing
             // the member so that it may rejoin later
@@ -972,7 +981,8 @@ where
                 .map_err(anyhow::Error::msg)
                 .map_err(Error::CustomBroadcast)?
             {
-                self.custom_broadcasts.add_or_replace(broadcast);
+                self.custom_broadcasts
+                    .add_or_replace(broadcast, self.config.max_transmissions.get().into());
             }
         }
 


### PR DESCRIPTION
These patches expose a new method `Foca::set_config` to allow tuning parameters at runtime, preserving the known cluster state and the current identity.

Additionally, if the `std` feature is set, two helpers are exposed to help create a config: `Config::new_wan` and `Config::new_lan`.

I didn't feel comfortable bringing in the whole dynamic configuration logic into Foca because:

- relevant parameters don't actually change much during normal operations
- the use case where cluster size changes drastically during normal ops is not super common and can be covered by `Foca::num_members` + `Foca::set_config`
- would need nightly's `core_instrinsics` (or jump into libm / another dep) for math on `no_std` 

Might revisit this decision in the future if I ever buy into lifeguard/awareness


Resolves #6