### PR TITLE
probe validation and recovery improvements

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -32,6 +32,10 @@ pub enum Error {
     /// steps didn't happen. Bug in the runtime/scheduling
     /// mechanism most likely.
     ///
+    /// Foca tries to resume normal operations after emitting this
+    /// error, but any occurance of it is a sign that something is
+    /// not behaving as expected
+    ///
     /// Must not happen under normal circumstances.
     IncompleteProbeCycle,
 


### PR DESCRIPTION
this:

- [x] ensures the probe state is clean if the instance goes idle in the middle of a probe cycle
- [x] makes foca go back to a fully functional state in case it detects another case of incomplete probe cycle

resolves #2 