### PR TITLE
Membership discovery and (self) awareness improvements

### DIFF
--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -207,6 +207,10 @@ where
             .windows(2)
             .all(|w| w[0].remaining_tx <= w[1].remaining_tx)
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.storage.is_empty()
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -239,13 +243,6 @@ impl<T: AsRef<[u8]>> Ord for Entry<T> {
 impl<T: AsRef<[u8]>> PartialOrd for Entry<T> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
-    }
-}
-
-#[cfg(test)]
-impl<T> Broadcasts<T> {
-    pub fn is_empty(&self) -> bool {
-        self.storage.is_empty()
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -94,10 +94,25 @@ pub struct Config {
     /// to a value smaller than your network's MTU.  1400 is a good
     /// value for a in a non-ancient network.
     pub max_packet_size: NonZeroUsize,
+
+    /// Wether foca should try to let members that are down know about it
+    ///
+    /// Whenever a member is declared down by the cluster, their messages
+    /// get ignored and there's no way for them to learn that this is happening.
+    /// With this setting enabled, will try to notify the down member that
+    /// their messages are being discarded.
+    ///
+    /// This feature is an extension to the SWIM protocol and should be left
+    /// disabled if you're aiming at pure SWIM behavior.
+    pub notify_down_members: bool,
 }
 
 impl Config {
     /// A simple configuration that should work well in a LAN scenario.
+    ///
+    /// This is Foca in its simplest form and has no extensions enabled.
+    /// Use this config if you are trying to get a grasp of how SWIM
+    /// works, without any additional behavior.
     pub fn simple() -> Self {
         Self {
             probe_period: Duration::from_millis(1500),
@@ -110,6 +125,8 @@ impl Config {
             remove_down_after: Duration::from_secs(15),
 
             max_packet_size: NonZeroUsize::new(1400).unwrap(),
+
+            notify_down_members: false,
         }
     }
 }
@@ -144,6 +161,8 @@ impl Config {
             remove_down_after: Duration::from_secs(15),
 
             max_packet_size: NonZeroUsize::new(1400).unwrap(),
+
+            notify_down_members: true,
         }
     }
 
@@ -169,6 +188,8 @@ impl Config {
             remove_down_after: Duration::from_secs(15),
 
             max_packet_size: NonZeroUsize::new(1400).unwrap(),
+
+            notify_down_members: true,
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -105,6 +105,39 @@ pub struct Config {
     /// This feature is an extension to the SWIM protocol and should be left
     /// disabled if you're aiming at pure SWIM behavior.
     pub notify_down_members: bool,
+
+    /// How often should foca ask its peers for more peers
+    ///
+    /// [`crate::Message::Announce`] is the mechanism foca uses to discover
+    /// members. After joining a sizeable cluster, it may take a while until
+    /// foca discovers every active member. Periodically announcing helps speed
+    /// up this process.
+    ///
+    /// This setting is helpful for any cluster size, but smaller ones can
+    /// get by without it if discovering the full active roster quickly is
+    /// not a requirement.
+    ///
+    /// As a rule of thumb, use large values for `frequency` (say, every
+    /// 30s, every minute, etc) and small values for `num_members`: just
+    /// one might be good enough for many clusters.
+    ///
+    /// Whilst you can change the parameters at runtime, foca prevents you from
+    /// changing it from `None` to `Some` to simplify reasoning. It's required
+    /// to recreate your foca instance in these cases.
+    ///
+    /// This feature is an extension to the SWIM protocol and should be left
+    /// disabled if you're aiming at pure SWIM behavior.
+    pub periodic_announce: Option<PeriodicParams>,
+}
+
+/// Configuration for a task that should happen periodically
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct PeriodicParams {
+    /// How often should the task be performed
+    pub frequency: Duration,
+    /// How many random members should be chosen
+    pub num_members: NonZeroUsize,
 }
 
 impl Config {
@@ -127,6 +160,8 @@ impl Config {
             max_packet_size: NonZeroUsize::new(1400).unwrap(),
 
             notify_down_members: false,
+
+            periodic_announce: None,
         }
     }
 }
@@ -163,6 +198,11 @@ impl Config {
             max_packet_size: NonZeroUsize::new(1400).unwrap(),
 
             notify_down_members: true,
+
+            periodic_announce: Some(PeriodicParams {
+                frequency: Duration::from_secs(30),
+                num_members: NonZeroUsize::new(1).unwrap(),
+            }),
         }
     }
 
@@ -190,6 +230,11 @@ impl Config {
             max_packet_size: NonZeroUsize::new(1400).unwrap(),
 
             notify_down_members: true,
+
+            periodic_announce: Some(PeriodicParams {
+                frequency: Duration::from_secs(60),
+                num_members: NonZeroUsize::new(2).unwrap(),
+            }),
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -128,6 +128,28 @@ pub struct Config {
     /// This feature is an extension to the SWIM protocol and should be left
     /// disabled if you're aiming at pure SWIM behavior.
     pub periodic_announce: Option<PeriodicParams>,
+
+    /// How often should foca send cluster updates to peers
+    ///
+    /// By default, SWIM disseminates cluster updates during the direct and
+    /// indirect probe cycle (See [`crate::Message`]). This setting instructs
+    /// foca to also propagate updates periodically.
+    ///
+    /// Periodically gossiping influences the speed in which the cluster learns
+    /// new information, but gossiping too much is often unnecessary since
+    /// cluster changes are not (normally) high-rate events.
+    ///
+    /// A LAN cluster can afford high frequency gossiping (every 200ms, for example)
+    /// without much worry; A WAN cluster might have better results gossiping less
+    /// often (500ms) but to more members at once.
+    ///
+    /// Whilst you can change the parameters at runtime, foca prevents you from
+    /// changing it from `None` to `Some` to simplify reasoning. It's required
+    /// to recreate your foca instance in these cases.
+    ///
+    /// This feature is an extension to the SWIM protocol and should be left
+    /// disabled if you're aiming at pure SWIM behavior.
+    pub periodic_gossip: Option<PeriodicParams>,
 }
 
 /// Configuration for a task that should happen periodically
@@ -162,6 +184,7 @@ impl Config {
             notify_down_members: false,
 
             periodic_announce: None,
+            periodic_gossip: None,
         }
     }
 }
@@ -203,6 +226,10 @@ impl Config {
                 frequency: Duration::from_secs(30),
                 num_members: NonZeroUsize::new(1).unwrap(),
             }),
+            periodic_gossip: Some(PeriodicParams {
+                frequency: Duration::from_millis(200),
+                num_members: NonZeroUsize::new(3).unwrap(),
+            }),
         }
     }
 
@@ -234,6 +261,10 @@ impl Config {
             periodic_announce: Some(PeriodicParams {
                 frequency: Duration::from_secs(60),
                 num_members: NonZeroUsize::new(2).unwrap(),
+            }),
+            periodic_gossip: Some(PeriodicParams {
+                frequency: Duration::from_millis(500),
+                num_members: NonZeroUsize::new(4).unwrap(),
             }),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -644,7 +644,15 @@ where
                             Timer::PeriodicGossip(self.timer_token),
                             params.frequency,
                         );
-                        self.choose_and_send(params.num_members.get(), Message::Gossip, runtime)?;
+
+                        // Only actually gossip if there are updates to send
+                        if !self.updates.is_empty() || !self.custom_broadcasts.is_empty() {
+                            self.choose_and_send(
+                                params.num_members.get(),
+                                Message::Gossip,
+                                runtime,
+                            )?;
+                        }
                     }
                 }
                 Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1152,6 +1152,7 @@ where
             // Seek back and write the correct number of items added
             buf.get_mut()[tally_position..].as_mut().put_u16(num_items);
             #[cfg(feature = "tracing")]
+            #[allow(clippy::needless_borrow)]
             span.record("num_updates", &num_items);
         }
 
@@ -1168,11 +1169,13 @@ where
             #[cfg_attr(not(feature = "tracing"), allow(unused_variables))]
             let num_broadcasts = self.custom_broadcasts.fill(&mut buf, usize::MAX);
             #[cfg(feature = "tracing")]
+            #[allow(clippy::needless_borrow)]
             span.record("num_broadcasts", &num_broadcasts);
         }
 
         let data = buf.into_inner();
         #[cfg(feature = "tracing")]
+        #[allow(clippy::needless_borrow)]
         span.record("len", &data.len());
 
         #[cfg(feature = "tracing")]

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -134,6 +134,12 @@ pub enum Message<T> {
     /// Deliberate dissemination of custom broadcasts. Broadcast
     /// messages do not contain cluster updates.
     Broadcast,
+
+    /// Indicates that the receiver is considered down by the sender
+    ///
+    /// This is an optional message that Foca sends whenever a member
+    /// that's considered down sends a message.
+    TurnUndead,
 }
 
 /// ProbeNumber is simply a bookkeeping mechanism to try and prevent

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -129,6 +129,10 @@ pub enum Timer<T> {
     /// Forgets about dead member `T`, allowing them to join the
     /// cluster again with the same identity.
     RemoveDown(T),
+
+    /// Sends a [`crate::Message::Announce`] to randomly chosen members as
+    /// specified by [`crate::Config::periodic_announce`]
+    PeriodicAnnounce(TimerToken),
 }
 
 /// TimerToken is simply a bookkeeping mechanism to try and prevent

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -133,6 +133,10 @@ pub enum Timer<T> {
     /// Sends a [`crate::Message::Announce`] to randomly chosen members as
     /// specified by [`crate::Config::periodic_announce`]
     PeriodicAnnounce(TimerToken),
+
+    /// Sends a [`crate::Message::Gossip`] to randomly chosen members as
+    /// specified by [`crate::Config::periodic_gossip`]
+    PeriodicGossip(TimerToken),
 }
 
 /// TimerToken is simply a bookkeeping mechanism to try and prevent

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -185,6 +185,7 @@ impl BadCodec {
             8 => Message::Announce,
             9 => Message::Feed,
             10 => Message::Broadcast,
+            11 => Message::TurnUndead,
             other => return Err(BadCodecError::BadMessageID(other)),
         };
 
@@ -251,6 +252,9 @@ impl BadCodec {
             }
             Message::Broadcast => {
                 buf.put_u8(10);
+            }
+            Message::TurnUndead => {
+                buf.put_u8(11);
             }
         }
 


### PR DESCRIPTION
Going through features discussed on #15. I'll slowly be ticking the boxes as I complete each:

- [x] A way for members to learn that their messages are being ignored, so they can react to the situation where they've been declared down but haven't received that info through normal means
- [x] Periodic `announce()` to increase the speed to discover the _whole_ cluster
- [x] Periodic `gossip()`, to speed up cluster update propagation
